### PR TITLE
fix undefined property caused uncaughtException in debug mode

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -176,11 +176,11 @@ TableStore.EventListeners = {
         var delta = (time - req.startTime.getTime()) / 1000;
         var ansi = logger.isTTY ? true : false;
         var status = resp.httpResponse.statusCode;
-        var params = require('util').inspect(req.params, true, true);
+        var params = require('util').inspect(req.params, { depth: null });
 
         var message = '';
         if (ansi) message += '\x1B[33m';
-        message += '[TableStore ' + req.service.serviceIdentifier + ' ' + status;
+        message += '[TableStore ' + ' ' + status;
         message += ' ' + delta.toString() + 's ' + resp.retryCount + ' retries]';
         if (ansi) message += '\x1B[0;1m';
         message += ' ' + req.operation + '(' + params + ')';


### PR DESCRIPTION
1. 修复logger调试模式下属性缺失导致的异常;
2. 修复logger调试模式下用户参数输出不完整的问题.