### PR TITLE
Added English README and Fixed time_stemp typo.

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -1,0 +1,45 @@
+# Aliyun TableStore SDK for Node.js
+
+[![License Status](https://img.shields.io/badge/license-apache2-brightgreen.svg)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
+[![GitHub version](https://badge.fury.io/gh/aliyun%2Faliyun-tablestore-nodejs-sdk.svg)](https://badge.fury.io/gh/aliyun%2Faliyun-tablestore-nodejs-sdk)
+[![Build Status](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
+[![Coverage Status](https://coveralls.io/repos/github/aliyun/aliyun-tablestore-nodejs-sdk/badge.svg?branch=master)](https://coveralls.io/github/aliyun/aliyun-tablestore-nodejs-sdk?branch=master)
+
+## About
+ - This NodeJs SDK is a client library for the [Alibaba Cloud Table Store Service](http://www.aliyun.com/product/ots/) API.
+ - Alibaba Cloud Table Store is a NoSQL database service built on Alibaba Cloud’s Apsara distributed operating system that can store and access large volumes of structured data in real time.
+
+## Version
+ - Current Version: 4.3.1
+
+## Version Feature Updates
+ - Queries are now supported using the "Long" datatype
+ - Added Support for SearchIndex
+ - Added Support for GlobalIndex
+ - Added Support for Atomic Addition
+ - Added Support for Transactions
+
+## Installation
+
+```sh
+npm install tablestore
+```
+
+## Getting Started
+To get started, we recommend taking a look at the samples found in the "samples/" directory. 
+You can configure the samples for use by setting the correct relevant parameters for your Table Store instance by modifying the "samples/client.js" file (modify the values for 'accessKeyId', 'secretAccessKey', 'endpoint' and 'instancename' accordingly).
+
+
+
+## Contributing
+ - We welcome everyone to contribute code to the TableStore NodeJs SDK and other TableStore SDKs.
+
+## Contact US
+- [Alibaba Cloud Table Store Official Product Page](https://www.alibabacloud.com/product/table-store)
+- [Alibaba Cloud Official Support Forum](https://www.alibabacloud.com/forum?)
+- [Alibaba Cloud Table Store Official Documentation](https://www.alibabacloud.com/help/product/27278.htm)
+- [Alibaba Cloud Official Blog](https://www.alibabacloud.com/blog)
+- [Create Alibaba Cloud Support Ticket (Must be logged in)](https://workorder.console.aliyun.com/#/ticket/createIndex)
+
+### Join our Table Store Chat Group on [DingDing Talk](https://www.dingtalk.com/en)
+![Image text](http://tablestore-doc.oss-cn-hangzhou.aliyuncs.com/tablestore_dingding.jpg?x-oss-process=image/resize,m_lfit,h_400)

--- a/README-EN.md
+++ b/README-EN.md
@@ -5,6 +5,8 @@
 [![Build Status](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
 [![Coverage Status](https://coveralls.io/repos/github/aliyun/aliyun-tablestore-nodejs-sdk/badge.svg?branch=master)](https://coveralls.io/github/aliyun/aliyun-tablestore-nodejs-sdk?branch=master)
 
+## [中文版 (Chinese README)](README.md)
+
 ## About
  - This NodeJs SDK is a client library for the [Alibaba Cloud Table Store Service](http://www.aliyun.com/product/ots/) API.
  - Alibaba Cloud Table Store is a NoSQL database service built on Alibaba Cloud’s Apsara distributed operating system that can store and access large volumes of structured data in real time.

--- a/README-EN.md
+++ b/README-EN.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
 [![Coverage Status](https://coveralls.io/repos/github/aliyun/aliyun-tablestore-nodejs-sdk/badge.svg?branch=master)](https://coveralls.io/github/aliyun/aliyun-tablestore-nodejs-sdk?branch=master)
 
-## [中文版 (Chinese README)](README.md)
+## [中文版 (Link to the Chinese README)](README.md)
 
 ## About
  - This NodeJs SDK is a client library for the [Alibaba Cloud Table Store Service](http://www.aliyun.com/product/ots/) API.

--- a/README-EN.md
+++ b/README-EN.md
@@ -8,14 +8,14 @@
 ## [中文版 (Link to the Chinese README)](README.md)
 
 ## About
- - This NodeJs SDK is a client library for the [Alibaba Cloud Table Store Service](http://www.aliyun.com/product/ots/) API.
- - Alibaba Cloud Table Store is a NoSQL database service built on Alibaba Cloud’s Apsara distributed operating system that can store and access large volumes of structured data in real time.
+ - This NodeJs SDK is a client library for the [Alibaba Cloud Tablestore Service](http://www.aliyun.com/product/ots/) API.
+ - Alibaba Cloud Tablestore is a NoSQL database service built on Alibaba Cloud’s Apsara distributed operating system that can store and access large volumes of structured data in real time.
 
 ## Version
  - Current Version: 4.3.1
 
 ## Version Feature Updates
- - Queries are now supported using the "Long" datatype
+ - Bug fixed: Queries are now supported using the "Long" datatype
  - Added Support for SearchIndex
  - Added Support for GlobalIndex
  - Added Support for Atomic Addition
@@ -29,19 +29,19 @@ npm install tablestore
 
 ## Getting Started
 To get started, we recommend taking a look at the samples found in the "samples/" directory. 
-You can configure the samples for use by setting the correct relevant parameters for your Table Store instance by modifying the "samples/client.js" file (modify the values for 'accessKeyId', 'secretAccessKey', 'endpoint' and 'instancename' accordingly).
+You can configure the samples for use by setting the correct relevant parameters for your Tablestore instance by modifying the "samples/client.js" file (modify the values for 'accessKeyId', 'secretAccessKey', 'endpoint' and 'instancename' accordingly).
 
 
 
 ## Contributing
- - We welcome everyone to contribute code to the TableStore NodeJs SDK and other TableStore SDKs.
+ - We welcome everyone to contribute code to the Tablestore NodeJs SDK and other Tablestore SDKs.
 
 ## Contact US
-- [Alibaba Cloud Table Store Official Product Page](https://www.alibabacloud.com/product/table-store)
+- [Alibaba Cloud Tablestore Official Product Page](https://www.alibabacloud.com/product/table-store)
 - [Alibaba Cloud Official Support Forum](https://www.alibabacloud.com/forum?)
-- [Alibaba Cloud Table Store Official Documentation](https://www.alibabacloud.com/help/product/27278.htm)
+- [Alibaba Cloud Tablestore Official Documentation](https://www.alibabacloud.com/help/product/27278.htm)
 - [Alibaba Cloud Official Blog](https://www.alibabacloud.com/blog)
 - [Create Alibaba Cloud Support Ticket (Must be logged in)](https://workorder.console.aliyun.com/#/ticket/createIndex)
 
-### Join our Table Store Chat Group on [DingDing Talk](https://www.dingtalk.com/en)
+### Join our Tablestore Chat Group on [DingDing Talk](https://www.dingtalk.com/en)
 ![Image text](http://tablestore-doc.oss-cn-hangzhou.aliyuncs.com/tablestore_dingding.jpg?x-oss-process=image/resize,m_lfit,h_400)

--- a/README-EN.md
+++ b/README-EN.md
@@ -1,4 +1,4 @@
-# Aliyun TableStore SDK for Node.js
+# Aliyun Tablestore SDK for Node.js
 
 [![License Status](https://img.shields.io/badge/license-apache2-brightgreen.svg)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
 [![GitHub version](https://badge.fury.io/gh/aliyun%2Faliyun-tablestore-nodejs-sdk.svg)](https://badge.fury.io/gh/aliyun%2Faliyun-tablestore-nodejs-sdk)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Build Status](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
 [![Coverage Status](https://coveralls.io/repos/github/aliyun/aliyun-tablestore-nodejs-sdk/badge.svg?branch=master)](https://coveralls.io/github/aliyun/aliyun-tablestore-nodejs-sdk?branch=master)
 
+# [Click here for the English README](README-EN.md)
+
 ## 关于
  - 此NodeJs SDK基于[阿里云表格存储服务](http://www.aliyun.com/product/ots/) API构建。
  - 阿里云表格存储是阿里云自主研发的NoSQL数据存储服务，提供海量结构化数据的存储和实时访问。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk.svg?branch=master)](https://travis-ci.org/aliyun/aliyun-tablestore-nodejs-sdk)
 [![Coverage Status](https://coveralls.io/repos/github/aliyun/aliyun-tablestore-nodejs-sdk/badge.svg?branch=master)](https://coveralls.io/github/aliyun/aliyun-tablestore-nodejs-sdk?branch=master)
 
-# [Click here for the English README](README-EN.md)
+## [Click here for the English README](README-EN.md)
 
 ## 关于
  - 此NodeJs SDK基于[阿里云表格存储服务](http://www.aliyun.com/product/ots/) API构建。

--- a/samples-async(node6)/searchPaginateByToken.js
+++ b/samples-async(node6)/searchPaginateByToken.js
@@ -25,7 +25,7 @@ var params = {
     },
     columnToGet: {
         returnType: TableStore.ColumnReturnType.RETURN_NONE,
-        returnNames: ["pic_tag", "pic_description", "time_stemp", "pos"]
+        returnNames: ["pic_tag", "pic_description", "time_stamp", "pos"]
     }
 };
 

--- a/samples/createSearchIndex.js
+++ b/samples/createSearchIndex.js
@@ -23,7 +23,7 @@ client.createSearchIndex({
                 isAnArray: false
             },
             {
-                fieldName: "time_stemp",
+                fieldName: "time_stamp",
                 fieldType: TableStore.FieldType.LONG,
                 index: true,
                 enableSortAndAgg: false,

--- a/samples/search.js
+++ b/samples/search.js
@@ -262,7 +262,7 @@ client.search({
     },
     columnToGet: {
         returnType: TableStore.ColumnReturnType.RETURN_SPECIFIED,
-        returnNames: ["pic_tag", "pic_description", "time_stemp", "pos"]
+        returnNames: ["pic_tag", "pic_description", "time_stamp", "pos"]
     },
     routingValues: [
         [{count: Long.fromNumber(0), pic_id: "pic_id_0"}],//pk顺序与创建index时routingFields一致

--- a/samples/search.js
+++ b/samples/search.js
@@ -157,7 +157,7 @@ var testQueryMap = {
                 }
             },
             fieldValueFactor: {
-                fieldName: "time_stemp"//数值字段
+                fieldName: "time_stamp"//数值字段
             }
         }
     },

--- a/samples/searchPaginateByToken.js
+++ b/samples/searchPaginateByToken.js
@@ -46,7 +46,7 @@ client.search({
         },
         columnToGet: {
             returnType: TableStore.ColumnReturnType.RETURN_NONE,
-            returnNames: ["pic_tag", "pic_description", "time_stemp", "pos"]
+            returnNames: ["pic_tag", "pic_description", "time_stamp", "pos"]
         }
     }, function (err, data) {
         console.log('token success:', JSON.stringify(data, null, 2));

--- a/samples/searchPaginateByToken.js
+++ b/samples/searchPaginateByToken.js
@@ -25,7 +25,7 @@ client.search({
     },
     columnToGet: {
         returnType: TableStore.ColumnReturnType.RETURN_NONE,
-        returnNames: ["pic_tag", "pic_description", "time_stemp", "pos"]
+        returnNames: ["pic_tag", "pic_description", "time_stamp", "pos"]
     }
 }, function (err, data) {
     var nextToken = data.nextToken.toString("base64", data.nextToken.offset, data.nextToken.limit);

--- a/test/searchIndexSearchAndDelete.test.js
+++ b/test/searchIndexSearchAndDelete.test.js
@@ -409,7 +409,7 @@ function getParams(type) {
         },
         columnToGet: {
             returnType: TableStore.ColumnReturnType.RETURN_ALL,
-            returnNames: ["pic_tag", "pic_des", "time_stemp", "pos"]
+            returnNames: ["pic_tag", "pic_des", "time_stamp", "pos"]
         }
     }
 }


### PR DESCRIPTION
In the fork [cf/aliyun-tablestore-nodejs-sdk](https://github.com/cf/aliyun-tablestore-nodejs-sdk), I added an English README-EN.md and fixed the time_stemp typo in the samples.

As Alibaba Cloud grows in popularity around the world, it's always good to have an English README to encourage intl. developers to use the service =).