### PR TITLE
attributeColumns ---> TupdateOfAttributeColumns

### DIFF
--- a/samples/batchWriteRow.js
+++ b/samples/batchWriteRow.js
@@ -12,7 +12,7 @@ var params = {
                     type: 'UPDATE',
                     condition: new TableStore.Condition(TableStore.RowExistenceExpectation.IGNORE, null),
                     primaryKey: [{ 'gid': Long.fromNumber(8) }, { 'uid': Long.fromNumber(80) }],
-                    attributeColumns: [{ 'PUT': [{ 'attrCol1': 'test3' }, { 'attrCol2': 'test4' }] }],
+                    updateOfAttributeColumns: [{ 'PUT': [{ 'attrCol1': 'test3' }, { 'attrCol2': 'test4' }] }],
                     returnContent: { returnType: 1 }
                 },
                 {


### PR DESCRIPTION
batchWriteRow 方法
type: 'UPDATE'时

因参考 updateRow的写法 attributeColumns 应该改为 updateOfAttributeColumns

实测 attributeColumns 报错
改为 updateOfAttributeColumns 后正确